### PR TITLE
WIP: Emotion rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "testURL": "http://localhost/"
   },
   "devDependencies": {
-    "@emotion/core": "^10.0.22",
+    "@emotion/react": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@types/html-webpack-plugin": "^3.2.1",
     "@types/jest": "^24.0.18",


### PR DESCRIPTION
It seems like authors of emotion did a retroactive push republishing all core versions as

```
"use strict";

throw new Error("The `@emotion/core` package has been renamed to `@emotion/react`. Please import it like this `import { jsx } from '@emotion/react'`.");


```

this make sit impossible for anyoen without a locally cached version of 10.0.23 to run this module.